### PR TITLE
redirect endpoint to only care about master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 
-[![Build Status](https://travis-ci.org/FenrirUnbound/football-spread.png?branch=feature/travis-ci)](https://travis-ci.org/FenrirUnbound/football-spread)
+[![Build Status](https://travis-ci.org/FenrirUnbound/football-spread.png?branch=master)](https://travis-ci.org/FenrirUnbound/football-spread)


### PR DESCRIPTION
Badge was incorrectly using the wrong branch to determine build status. This has be rectified to use only the `master` branch (since feature branches may fail but do not necessarily mean the project itself is failing).
