### PR TITLE
update team names

### DIFF
--- a/lib/constants.py
+++ b/lib/constants.py
@@ -61,8 +61,9 @@ class NFL():
         "GREEN BAY": "GB",
         "HOUSTON": "HOU",
         "INDIANAPOLIS": "IND",
-        "JACKSONVILLE": "JAC",
+        "JACKSONVILLE": "JAX",
         "KANSAS CITY": "KC",
+        "LOS ANGELES": "LA",
         "MIAMI": "MIA",
         "MINNESOTA": "MIN",
         "NEW ENGLAND": "NE",
@@ -75,7 +76,6 @@ class NFL():
         "SAN DIEGO": "SD",
         "SAN FRANCISCO": "SF",
         "SEATTLE": "SEA",
-        "ST. LOUIS": "STL",
         "TAMPA BAY": "TB",
         "TENNESSEE": "TEN",
         "WASHINGTON": "WAS"


### PR DESCRIPTION
Change the team names in the BE.
- Jacksonville is now listed as `jax` instead of `jac`
- The Rams have moved from _St. Louis_ to _Los Angeles_
